### PR TITLE
Add MUMPS support on Windows (MSYS2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,53 @@ bash zscripts/compile-and-install-suitesparse.bash
 
 ### Optional feature "with_mumps"
 
-`russell_sparse` has an optional feature named `with_mumps` which enables the MUMPS solver. To use this feature, MUMPS needs to be locally compiled first. The [compile-and-install-mumps](https://github.com/cpmech/russell/blob/main/zscripts/compile-and-install-mumps.bash) script may be used in this case:
+`russell_sparse` has an optional feature named `with_mumps` which enables the MUMPS solver. To use this feature, MUMPS needs to be locally compiled first. On Linux/macOS, the [compile-and-install-mumps](https://github.com/cpmech/russell/blob/main/zscripts/compile-and-install-mumps.bash) script may be used:
 
 ```bash
 bash zscripts/compile-and-install-mumps.bash
+```
+
+On Windows (MSYS2), MUMPS can be compiled using the following steps:
+
+*Install compilation dependencies (in MSYS2 UCRT64 terminal):*
+
+```bash
+pacman -S mingw-w64-ucrt-x86_64-gcc-fortran
+pacman -S mingw-w64-ucrt-x86_64-make
+pacman -S mingw-w64-ucrt-x86_64-cmake
+pacman -S mingw-w64-ucrt-x86_64-clang
+pacman -S mingw-w64-ucrt-x86_64-metis
+```
+
+*Download and compile MUMPS:*
+
+```bash
+cd /tmp
+curl http://deb.debian.org/debian/pool/main/m/mumps/mumps_5.8.2.orig.tar.gz -o mumps_5.8.2.orig.tar.gz
+tar xzf mumps_5.8.2.orig.tar.gz
+cd MUMPS_5.8.2
+
+# Copy the MSYS2 configuration file
+cp /c/path/to/russell/zscripts/makefiles-mumps/Makefile.inc.msys2 Makefile.inc
+
+# Compile double precision (real) version
+make d
+
+# Compile complex version
+make clean
+make z
+```
+
+*Install MUMPS libraries and headers:*
+
+```bash
+# Copy libraries to /ucrt64/lib/mumps
+mkdir -p /ucrt64/lib/mumps
+cp lib/*.a /ucrt64/lib/mumps/
+
+# Copy headers to /ucrt64/include/mumps
+mkdir -p /ucrt64/include/mumps
+cp include/*.h /ucrt64/include/mumps/
 ```
 
 ### Optional feature "intel_mkl"
@@ -904,4 +947,4 @@ fn main() -> Result<(), StrError> {
 - [ ] General improvements
     - [x] Compile on macOS
     - [x] Compile on Windows
-    - [ ] Compile MUMPS on Windows
+    - [x] Compile MUMPS on Windows

--- a/russell_sparse/build.rs
+++ b/russell_sparse/build.rs
@@ -6,7 +6,7 @@ fn main() {
         let msys2_prefix = std::env::var("MSYS2_PREFIX").unwrap();
         let include_path = format!("{}/include/suitesparse", msys2_prefix);
         let lib_path = format!("{}/lib", msys2_prefix);
-        
+
         cc::Build::new()
             .file("c_code/interface_complex_klu.c")
             .file("c_code/interface_complex_umfpack.c")
@@ -14,7 +14,7 @@ fn main() {
             .file("c_code/interface_umfpack.c")
             .include(&include_path)
             .compile("c_code_suitesparse");
-        
+
         println!("cargo:rustc-link-search=native={}", lib_path);
         for l in &libs {
             println!("cargo:rustc-link-lib=dylib={}", *l);
@@ -65,13 +65,38 @@ fn main() {
 
     #[cfg(feature = "with_mumps")]
     {
-        cc::Build::new()
-            .file("c_code/interface_complex_mumps.c")
-            .file("c_code/interface_mumps.c")
-            .include("/usr/local/include/mumps")
-            .compile("c_code_mumps");
-        println!("cargo:rustc-link-search=native=/usr/local/lib/mumps");
-        println!("cargo:rustc-link-lib=dylib=dmumps_cpmech");
-        println!("cargo:rustc-link-lib=dylib=zmumps_cpmech");
+        #[cfg(target_os = "windows")]
+        {
+            let msys2_prefix = std::env::var("MSYS2_PREFIX").unwrap();
+            let mumps_include = format!("{}/include/mumps", msys2_prefix);
+            let mumps_lib = format!("{}/lib/mumps", msys2_prefix);
+
+            cc::Build::new()
+                .file("c_code/interface_complex_mumps.c")
+                .file("c_code/interface_mumps.c")
+                .include(&mumps_include)
+                .compile("c_code_mumps");
+            println!("cargo:rustc-link-search=native={}", mumps_lib);
+            println!("cargo:rustc-link-lib=static=dmumps_cpmech");
+            println!("cargo:rustc-link-lib=static=zmumps_cpmech");
+            println!("cargo:rustc-link-lib=static=mumps_common_cpmech");
+            println!("cargo:rustc-link-lib=static=mpiseq_cpmech");
+            println!("cargo:rustc-link-lib=static=pord_cpmech");
+            println!("cargo:rustc-link-lib=dylib=gfortran");
+            println!("cargo:rustc-link-lib=dylib=gomp");
+            println!("cargo:rustc-link-lib=static=metis");
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            cc::Build::new()
+                .file("c_code/interface_complex_mumps.c")
+                .file("c_code/interface_mumps.c")
+                .include("/usr/local/include/mumps")
+                .compile("c_code_mumps");
+            println!("cargo:rustc-link-search=native=/usr/local/lib/mumps");
+            println!("cargo:rustc-link-lib=dylib=dmumps_cpmech");
+            println!("cargo:rustc-link-lib=dylib=zmumps_cpmech");
+        }
     }
 }

--- a/zscripts/makefiles-mumps/Makefile.inc.msys2
+++ b/zscripts/makefiles-mumps/Makefile.inc.msys2
@@ -1,0 +1,68 @@
+#
+#  This file is part of MUMPS 5.7.1, released
+#  on Thu May  2 10:15:09 UTC 2024
+#
+#  Modified for MSYS2 UCRT64 (Windows)
+#
+
+# must be at the top
+PLAT = _cpmech
+
+# Begin orderings
+SCOTCHDIR =
+ISCOTCH   =
+
+LSCOTCH   =
+
+LPORDDIR = $(topdir)/PORD/lib/
+IPORD    = -I$(topdir)/PORD/include/
+LPORD    = -L$(LPORDDIR) -lpord$(PLAT)
+
+LMETISDIR = C:/msys64/ucrt64/lib
+IMETIS    = -IC:/msys64/ucrt64/include
+
+LMETIS    = -L$(LMETISDIR) -lmetis
+
+# Corresponding variables reused later
+ORDERINGSF = -Dmetis -Dpord
+ORDERINGSC  = $(ORDERINGSF)
+
+LORDERINGS = -LC:/msys64/ucrt64/lib $(LMETIS) $(LPORD) $(LSCOTCH)
+IORDERINGSF = $(ISCOTCH)
+IORDERINGSC = $(IMETIS) $(IPORD) $(ISCOTCH)
+# End orderings
+################################################################################
+
+LIBEXT_SHARED  = .dll
+SONAME = -soname
+SHARED_OPT = -shared
+FPIC_OPT = -fPIC
+LIBEXT  = .a
+OUTC    = -o
+OUTF    = -o
+RM = rm -f
+CC = gcc
+FC = gfortran
+FL = gfortran
+AR = ar r
+RANLIB =
+LAPACK = -lopenblas
+
+INCSEQ = -I$(topdir)/libseq
+LIBSEQ  = $(LAPACK) -L$(topdir)/libseq -lmpiseq$(PLAT)
+
+LIBBLAS = -lopenblas
+LIBOTHERS = -lpthread
+
+#Preprocessor defs for calling Fortran from C (-DAdd_ or -DAdd__ or -DUPPER)
+CDEFS   = -DAdd_
+
+#Begin Optimized options
+OPTF    = -O -fopenmp -fallow-argument-mismatch
+OPTL    = -O -fopenmp
+OPTC    = -O -fopenmp
+#End Optimized options
+
+INCS = $(INCSEQ)
+LIBS = $(LIBSEQ)
+LIBSEQNEEDED = libseqneeded

--- a/zscripts/makefiles-mumps/Makefile.inc.msys2
+++ b/zscripts/makefiles-mumps/Makefile.inc.msys2
@@ -44,8 +44,8 @@ RM = rm -f
 CC = gcc
 FC = gfortran
 FL = gfortran
-AR = ar r
-RANLIB =
+AR = ar r 
+RANLIB = ar s
 LAPACK = -lopenblas
 
 INCSEQ = -I$(topdir)/libseq


### PR DESCRIPTION
# Add MUMPS support on Windows (MSYS2)

## Summary

This PR adds support for compiling Russell with the MUMPS sparse linear solver on Windows using the MSYS2 environment. It completes the roadmap item "Compile MUMPS on Windows".

## Changes

### New Files

- **`zscripts/makefiles-mumps/Makefile.inc.msys2`**: MUMPS configuration file for MSYS2 UCRT64

### Modified Files

- **`russell_sparse/build.rs`**: Added Windows-specific build configuration for MUMPS
- **`README.md`**: Updated documentation with MUMPS compilation instructions for Windows and marked roadmap item as complete

## Details

### 1. MUMPS Configuration for MSYS2

Created `Makefile.inc.msys2` with the following key adaptations for Windows:

| Setting | Linux | MSYS2 |
|---------|-------|-------|
| `AR` | `ar vr` | `ar r ` (with trailing space) |
| `RANLIB` | `ranlib` | `ar s ` (with trailing space) |
| `LAPACK` | `-llapack` | `-lopenblas` |
| `LIBBLAS` | `-lblas` | `-lopenblas` |

### 2. Build Script Updates

Modified `russell_sparse/build.rs` to support Windows MUMPS:

- Uses `MSYS2_PREFIX` environment variable to locate libraries
- Links required MUMPS libraries: `dmumps_cpmech`, `zmumps_cpmech`, `mumps_common_cpmech`, `mpiseq_cpmech`, `pord_cpmech`
- Links dependencies: `gfortran`, `gomp`, `metis`

### 3. Documentation

- Added MUMPS compilation instructions to README.md under "Optional feature with_mumps"
- Updated roadmap to mark "Compile MUMPS on Windows" as completed

## Requirements

### MSYS2 Packages

```bash
pacman -S mingw-w64-ucrt-x86_64-gcc-fortran
pacman -S mingw-w64-ucrt-x86_64-make
pacman -S mingw-w64-ucrt-x86_64-cmake
pacman -S mingw-w64-ucrt-x86_64-clang
pacman -S mingw-w64-ucrt-x86_64-metis
```

### Testing

```bash
cargo test --features with_mumps
```

## Related Issues

- Closes # (add issue number if applicable)
- Related to Roadmap: "Compile MUMPS on Windows"

## Checklist

- [x] MUMPS compiles successfully on Windows MSYS2
- [x] Russell tests pass with `--features with_mumps` on Windows
- [x] Documentation updated
- [x] Roadmap updated

---