### PR TITLE
Fix bessel_in accuracy loss for |x| > n

### DIFF
--- a/russell_lab/src/math/bessel_mod.rs
+++ b/russell_lab/src/math/bessel_mod.rs
@@ -78,6 +78,9 @@ pub fn bessel_i1(x: f64) -> f64 {
 // controls the accuracy in bessel_in
 const ACC: f64 = 200.0;
 
+// |x| above which In(x) overflows f64 for every n ≤ |x|
+const X_ALL_OVERFLOW: f64 = 1400.0;
+
 // half DBL_MAX_EXP
 const HALF_MAX_EXP: i32 = f64::MAX_EXP / 2;
 
@@ -114,7 +117,10 @@ pub fn bessel_in(n: usize, x: f64) -> f64 {
     let tox = 2.0 / f64::abs(x);
     let mut bip = 0.0;
     let mut bi = 1.0;
-    let mut j = 2 * (n + (f64::sqrt(ACC * (n as f64)) as usize));
+    // Miller's downward recurrence must start above max(n, |x|), otherwise it has
+    // not converged to In by the time it reaches order n (accuracy degrades with x)
+    let m = n.max(f64::min(f64::abs(x), X_ALL_OVERFLOW) as usize);
+    let mut j = 2 * (m + (f64::sqrt(ACC * (m as f64)) as usize));
     let mut ans: f64 = 0.0;
     while j > 0 {
         // downward recurrence
@@ -501,7 +507,7 @@ mod tests {
             (2,  1.0, 1e-16, 0.13574766976703828118285256999499092294987106811278),
             (2,  2.0, 1e-15, 0.68894844769873820405495001581186710533136294328992),
             (2, -5.0, 1e-14, 17.505614966624236014887011895180415898253112084901),
-            (3, -4.0, 1e-50, -3.3372757784203443678565186677519188526713389054441),
+            (3, -4.0, 1e-15, -3.3372757784203443678565186677519188526713389054441),
             (3,  1.0, 1e-17, 0.022168424924331902476285747629899615529415349169979),
             (3,  2.0, 1e-16, 0.21273995923985265527235439337593203729175227291569),
             (3, -5.0, 1e-50, -10.331150169151138387233440935615675741962384700378),
@@ -517,6 +523,41 @@ mod tests {
         for (n, x, tol, reference) in mathematica {
             // println!("n = {}, x = {:?}", n, x);
             approx_eq(bessel_in(n, x), reference, tol);
+        }
+    }
+
+    #[test]
+    fn bessel_in_with_large_x_works() {
+        // mpmath: mp.mp.dps = 50; mp.besseli(n, x), scaled by the power of ten in the third column
+        // before scaling the recurrence start index with |x|, the error at these points reached 2.6e-2 (n = 3, x = 700)
+        #[rustfmt::skip]
+        let mpmath = [
+            (2,    50.0, 1e20,  1e-14, 2.81643064024519405478),
+            (2,   100.0, 1e42,  1e-14, 1.05238431932431057390),
+            (2,   200.0, 1e85,  1e-14, 2.01934135791640399251),
+            (2,   300.0, 1e128, 1e-14, 4.44605815870147242201),
+            (2,  -300.0, 1e128, 1e-14, 4.44605815870147242201),
+            (2,   500.0, 1e215, 1e-14, 2.49480026292137369657),
+            (2,   700.0, 1e302, 1e-14, 1.52522620369977687721),
+            (3,   200.0, 1e85,  1e-14, 1.99419472217373462358),
+            (3,   500.0, 1e215, 1e-14, 2.48234501007272900612),
+            (3,  -500.0, 1e215, 1e-14, -2.48234501007272900612),
+            (3,   700.0, 1e302, 1e-14, 1.51978481192704482028),
+            (4,   300.0, 1e128, 1e-14, 4.35787614650972039304),
+            (4,   700.0, 1e302, 1e-14, 1.51219947674040220732),
+            (5,   100.0, 1e41,  1e-14, 9.47009387303558124618),
+            (5,   500.0, 1e215, 1e-14, 2.44290481610792099094),
+            (5,   700.0, 1e302, 1e-14, 1.50250253219286879505),
+            (5,  -700.0, 1e302, 1e-14, -1.50250253219286879505),
+            (10,  300.0, 1e128, 1e-14, 3.78772592586686867664),
+            (10,  700.0, 1e302, 1e-14, 1.42407639992908212288),
+            (100,  90.0, 1e15,  1e-13, 2.33411933125872852109),
+            (100, 120.0, 1e33,  1e-14, 2.52641327611942263157),
+            (300, 350.0, 1e97,  1e-14, 1.89620370751083282052),
+        ];
+        for (n, x, scale, tol, reference) in mpmath {
+            // println!("n = {}, x = {:?}", n, x);
+            approx_eq(bessel_in(n, x) / scale, reference, tol);
         }
     }
 
@@ -538,6 +579,13 @@ mod tests {
             1.250000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e-307,
             1e-322,
         );
+
+        //
+        // |x| > X_ALL_OVERFLOW (In(x) overflows f64 for every n ≤ |x|)
+        //
+        assert_eq!(bessel_in(2, 1500.0), f64::INFINITY);
+        assert_eq!(bessel_in(3, -1500.0), f64::NEG_INFINITY);
+        assert_eq!(bessel_in(2, 1e300), f64::INFINITY);
     }
 
     #[test]


### PR DESCRIPTION
`bessel_in` starts Miller's downward recurrence at `j = 2*(n + sqrt(ACC*n))`, which scales with the order only (same as the classic Numerical Recipes `bessi` routine it follows). Backward recurrence only converges to the minimal solution `In` when started well above `max(n, |x|)`, so for `|x| > n` the recurrence starts inside the oscillatory zone and accuracy degrades progressively with `x`:

| x | n=2 | n=3 | n=5 |
|---|-----|-----|-----|
| 100 | 9.0e-11 | 3.1e-13 | exact |
| 200 | 8.4e-07 | 6.1e-07 | 7.6e-12 |
| 300 | 1.6e-05 | 8.7e-05 | 4.4e-08 |
| 500 | 1.4e-04 | 4.8e-03 | 4.9e-05 |
| 700 | 3.0e-04 | 2.6e-02 | 1.0e-03 |

(relative error vs mpmath at 50 digits; scipy agrees with mpmath to ~3e-16)

The fix starts the recurrence from `m = max(n, |x|)` instead of `n`, keeping the formula otherwise. With it, every point above is within a few ulp (worst 5.2e-16). `|x|` is clamped at 1400 because `In(x)` overflows f64 for every `n <= |x|` beyond that point (the smallest of them, `I_x(x)`, exceeds f64::MAX from `x = 1345`), so a larger start would only spend iterations before the I0 normalization yields Inf — and without a clamp, `x = 1e300` would saturate the `as usize` cast. Cost becomes O(max(n, |x|)): ~9 µs at `x = 700` (was ~0.2 µs). The `n >= |x|` path is unchanged.

The new test grid uses mpmath (dps=50) reference values, scaled by powers of ten like the `beta.rs` tests since `approx_eq` compares absolute differences. It also pins the transition regime (`n ~ x`: 100/120, 300/350) and the overflow saturation. One existing tolerance is relaxed: `(3, -4)` matched its 50-digit reference bit-exactly with the old start and now sits 1 ulp away (the longer recurrence changes the rounding path for `|x| > n`), so its tol goes from 1e-50 to 1e-15.

Two observations from checking the rest of the module, for the record: `bessel_jn`/`bessel_yn`/`bessel_kn` are unaffected (`jn` switches to forward recursion for `n < x`; upward recurrence is stable for Y and K). And for `x` in roughly (710, 1341) with `n` close to `x`, `In(x)` is finite but the routine returns Inf because it normalizes through `I0(x)`, which overflows first — pre-existing behavior, unchanged here; it would need an exponent-scaled I0 if that range ever matters.
