### PR TITLE
Fixes hardcoded library paths preventing correct linking under Nix

### DIFF
--- a/russell_lab/Cargo.toml
+++ b/russell_lab/Cargo.toml
@@ -27,6 +27,7 @@ serial_test = "3.5"
 
 [build-dependencies]
 cc = "1.2"
+pkg-config = "0.3"
 
 [[bench]]
 name = "algo_chebyshev"

--- a/russell_lab/build.rs
+++ b/russell_lab/build.rs
@@ -43,26 +43,54 @@ fn compile_blas() {
 
     #[cfg(not(target_os = "windows"))]
     {
-        cc::Build::new()
-            .file("c_code/interface_blas.c")
-            .includes(&[
-                "/usr/include/openblas",
-                "/opt/homebrew/opt/lapack/include",
-                "/opt/homebrew/opt/openblas/include",
-                "/usr/local/opt/lapack/include",
-                "/usr/local/opt/openblas/include",
-            ])
-            .compile("c_code_interface_blas");
-        for d in &[
-            "/opt/homebrew/opt/lapack/lib",
-            "/opt/homebrew/opt/openblas/lib",
-            "/usr/local/opt/lapack/lib",
-            "/usr/local/opt/openblas/lib",
-        ] {
-            println!("cargo:rustc-link-search=native={}", *d);
+        // Try pkg-config first (e.g., Nix's `blas`/`lapack`/`cblas` outputs,
+        // or a distribution's OpenBLAS package that registers "openblas",
+        // "cblas", "lapack" — naming is unfortunately not standardized
+        // across distributions/build systems). Only fall back to the
+        // hardcoded search paths below (used by Homebrew and some manual
+        // installs) when pkg-config cannot find them.
+        //
+        // NOTE: this is a minimal fix, just enough to let pkg-config-based
+        // environments (such as a Nix devShell) resolve the *same* BLAS/
+        // LAPACK implementation that russell_sparse's SuiteSparse links
+        // against (mixing an ILP64 OpenBLAS build with an LP64 one is a
+        // silent ABI mismatch that segfaults at runtime).
+        let cblas = pkg_config::Config::new().probe("cblas");
+        let lapack = pkg_config::Config::new().probe("lapack");
+
+        let mut build = cc::Build::new();
+        build.file("c_code/interface_blas.c");
+
+        match (&cblas, &lapack) {
+            (Ok(cblas), Ok(lapack)) => {
+                for inc in cblas.include_paths.iter().chain(&lapack.include_paths) {
+                    build.include(inc);
+                }
+                build.compile("c_code_interface_blas");
+                // pkg-config already emitted the correct
+                // cargo:rustc-link-search/cargo:rustc-link-lib directives.
+            }
+            _ => {
+                build.includes(&[
+                    "/usr/include/openblas",
+                    "/opt/homebrew/opt/lapack/include",
+                    "/opt/homebrew/opt/openblas/include",
+                    "/usr/local/opt/lapack/include",
+                    "/usr/local/opt/openblas/include",
+                ]);
+                build.compile("c_code_interface_blas");
+                for d in &[
+                    "/opt/homebrew/opt/lapack/lib",
+                    "/opt/homebrew/opt/openblas/lib",
+                    "/usr/local/opt/lapack/lib",
+                    "/usr/local/opt/openblas/lib",
+                ] {
+                    println!("cargo:rustc-link-search=native={}", *d);
+                }
+                println!("cargo:rustc-link-lib=dylib=openblas");
+                println!("cargo:rustc-link-lib=dylib=lapack");
+            }
         }
-        println!("cargo:rustc-link-lib=dylib=openblas");
-        println!("cargo:rustc-link-lib=dylib=lapack");
     }
 }
 

--- a/russell_lab/build.rs
+++ b/russell_lab/build.rs
@@ -43,34 +43,26 @@ fn compile_blas() {
 
     #[cfg(not(target_os = "windows"))]
     {
-        // Try pkg-config first (e.g., Nix's `blas`/`lapack`/`cblas` outputs,
-        // or a distribution's OpenBLAS package that registers "openblas",
-        // "cblas", "lapack" — naming is unfortunately not standardized
-        // across distributions/build systems). Only fall back to the
-        // hardcoded search paths below (used by Homebrew and some manual
-        // installs) when pkg-config cannot find them.
-        //
-        // NOTE: this is a minimal fix, just enough to let pkg-config-based
-        // environments (such as a Nix devShell) resolve the *same* BLAS/
-        // LAPACK implementation that russell_sparse's SuiteSparse links
-        // against (mixing an ILP64 OpenBLAS build with an LP64 one is a
-        // silent ABI mismatch that segfaults at runtime).
-        let cblas = pkg_config::Config::new().probe("cblas");
-        let lapack = pkg_config::Config::new().probe("lapack");
-
         let mut build = cc::Build::new();
         build.file("c_code/interface_blas.c");
 
-        match (&cblas, &lapack) {
-            (Ok(cblas), Ok(lapack)) => {
-                for inc in cblas.include_paths.iter().chain(&lapack.include_paths) {
+        match probe_blas_lapack() {
+            Some(found) => {
+                for inc in &found.include_paths {
                     build.include(inc);
                 }
                 build.compile("c_code_interface_blas");
-                // pkg-config already emitted the correct
-                // cargo:rustc-link-search/cargo:rustc-link-lib directives.
+                for dir in &found.link_paths {
+                    println!("cargo:rustc-link-search=native={}", dir.display());
+                }
+                for lib in &found.libs {
+                    println!("cargo:rustc-link-lib=dylib={}", lib);
+                }
             }
-            _ => {
+            None => {
+                // For setups pkg-config knows nothing about, mainly Homebrew:
+                // openblas and lapack are keg-only there, so their .pc files
+                // are off the default `PKG_CONFIG_PATH`.
                 build.includes(&[
                     "/usr/include/openblas",
                     "/opt/homebrew/opt/lapack/include",
@@ -92,6 +84,77 @@ fn compile_blas() {
             }
         }
     }
+}
+
+/// The include/link information needed to build and link `interface_blas.c`.
+#[cfg(all(not(target_os = "windows"), not(feature = "intel_mkl")))]
+struct BlasLapack {
+    include_paths: Vec<std::path::PathBuf>,
+    link_paths: Vec<std::path::PathBuf>,
+    libs: Vec<String>,
+}
+
+/// Finds BLAS/LAPACK via `pkg-config`. Returns `None` if there is no usable
+/// answer, so the caller can fall back to hardcoded paths.
+///
+/// Tries `openblas` first (one module with both headers), then the neutral
+/// `cblas` + `lapack` pair that Nix uses.
+///
+/// A successful `pkg-config` run is not enough: we also check that the headers
+/// are really there. The `lapack` module means different things on different
+/// distros — on RHEL/Rocky it is netlib LAPACK, which registers `lapack.pc`
+/// but ships no `lapack.h`, so we would end up with no usable `-I` and fail
+/// to compile instead of falling back.
+#[cfg(all(not(target_os = "windows"), not(feature = "intel_mkl")))]
+fn probe_blas_lapack() -> Option<BlasLapack> {
+    // Only emit the cargo directives once we know the answer is usable.
+    let probe = |name: &str| {
+        pkg_config::Config::new()
+            .cargo_metadata(false)
+            .probe(name)
+            .ok()
+    };
+
+    let candidates: Vec<Vec<pkg_config::Library>> = vec![
+        probe("openblas").into_iter().collect(),
+        probe("cblas")
+            .into_iter()
+            .chain(probe("lapack"))
+            .collect::<Vec<_>>(),
+    ];
+
+    for libraries in candidates {
+        if libraries.is_empty() {
+            continue;
+        }
+        let found = BlasLapack {
+            include_paths: libraries.iter().flat_map(|l| l.include_paths.clone()).collect(),
+            link_paths: libraries.iter().flat_map(|l| l.link_paths.clone()).collect(),
+            libs: libraries.iter().flat_map(|l| l.libs.clone()).collect(),
+        };
+        if headers_available(&found.include_paths) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Checks that both headers used by `interface_blas.c` can actually be found.
+///
+/// The default include dirs count too: Debian/Ubuntu put `lapack.h` directly
+/// in `/usr/include`, where no `-I` is needed.
+#[cfg(all(not(target_os = "windows"), not(feature = "intel_mkl")))]
+fn headers_available(include_paths: &[std::path::PathBuf]) -> bool {
+    let implicit = [
+        std::path::PathBuf::from("/usr/include"),
+        std::path::PathBuf::from("/usr/local/include"),
+    ];
+    ["cblas.h", "lapack.h"].iter().all(|header| {
+        include_paths
+            .iter()
+            .chain(&implicit)
+            .any(|dir| dir.join(header).is_file())
+    })
 }
 
 fn main() {

--- a/russell_lab/c_code/interface_blas.c
+++ b/russell_lab/c_code/interface_blas.c
@@ -78,15 +78,10 @@ int32_t c_using_intel_mkl() {
 }
 
 #ifndef USE_INTEL_MKL
-// Some distributions/build systems (e.g., a generic, vendor-neutral cblas.h
-// as opposed to OpenBLAS' own `cblas.h` with its extensions) do not declare
-// these OpenBLAS-specific threading functions in any header, even though
-// the symbols are always present in the OpenBLAS shared library itself
-// (they are baked into `libblas.so`/`liblapack.so` on distributions that
-// implement the standard BLAS/LAPACK ABI using OpenBLAS under the hood,
-// such as Nix's `blas`/`lapack` packages). Forward-declaring them here is
-// harmless even when `cblas.h` already declares them, since the signatures
-// match exactly.
+// A vendor-neutral `cblas.h` does not declare these OpenBLAS threading calls,
+// even though the symbols are there whenever `libblas` is OpenBLAS underneath
+// (as with Nix's blas/lapack). Declaring them here is harmless when `cblas.h`
+// already does, as the signatures match.
 extern void openblas_set_num_threads(int num_threads);
 extern int openblas_get_num_threads(void);
 #endif

--- a/russell_lab/c_code/interface_blas.c
+++ b/russell_lab/c_code/interface_blas.c
@@ -77,6 +77,20 @@ int32_t c_using_intel_mkl() {
 #endif
 }
 
+#ifndef USE_INTEL_MKL
+// Some distributions/build systems (e.g., a generic, vendor-neutral cblas.h
+// as opposed to OpenBLAS' own `cblas.h` with its extensions) do not declare
+// these OpenBLAS-specific threading functions in any header, even though
+// the symbols are always present in the OpenBLAS shared library itself
+// (they are baked into `libblas.so`/`liblapack.so` on distributions that
+// implement the standard BLAS/LAPACK ABI using OpenBLAS under the hood,
+// such as Nix's `blas`/`lapack` packages). Forward-declaring them here is
+// harmless even when `cblas.h` already declares them, since the signatures
+// match exactly.
+extern void openblas_set_num_threads(int num_threads);
+extern int openblas_get_num_threads(void);
+#endif
+
 void c_set_num_threads(int32_t n) {
 #ifdef USE_INTEL_MKL
     MKL_Set_Num_Threads(n);

--- a/russell_sparse/Cargo.toml
+++ b/russell_sparse/Cargo.toml
@@ -28,3 +28,4 @@ serial_test = "3.5"
 
 [build-dependencies]
 cc = "1.2"
+pkg-config = "0.3"

--- a/russell_sparse/build.rs
+++ b/russell_sparse/build.rs
@@ -78,7 +78,15 @@ fn main() {
 
     #[cfg(not(target_os = "windows"))]
     {
-        let inc_dirs = vec![
+        // Fallback search directories, used only when pkg-config cannot locate
+        // the required libraries (e.g., locally compiled SuiteSparse/MUMPS via
+        // zscripts/*-compile-*.bash, Homebrew, or the proprietary cuDSS
+        // distribution — none of which ship .pc files). Non-existing
+        // directories are filtered out so that they never end up as bogus
+        // `-I`/`-L` flags on the compiler/linker command line; besides being
+        // noisy, stale entries like `/usr/lib` can shadow the libraries that
+        // an active Nix devShell injects via NIX_CFLAGS_COMPILE/NIX_LDFLAGS.
+        let inc_dirs = existing_dirs(&[
             "/opt/homebrew/include/suitesparse",
             "/usr/include/suitesparse",
             "/usr/local/include/mumps",
@@ -86,9 +94,9 @@ fn main() {
             "/usr/local/cuda/include",
             "/opt/cuda/include",
             "/opt/libcudss/include",
-        ];
+        ]);
 
-        let lib_dirs = vec![
+        let lib_dirs = existing_dirs(&[
             "/opt/homebrew/lib",
             "/usr/lib/x86_64-linux-gnu",
             "/usr/lib",
@@ -98,7 +106,7 @@ fn main() {
             "/usr/local/cuda/lib64",
             "/opt/cuda/lib64",
             "/opt/libcudss/lib",
-        ];
+        ]);
 
         // cudss && local_sparse
         #[cfg(all(feature = "cudss", feature = "local_sparse"))]
@@ -175,19 +183,89 @@ fn main() {
         }
 
         // not(cudss) && not(local_sparse)
+        //
+        // This is "Option 1" in README.md: UMFPACK (and its SuiteSparse
+        // dependencies) coming from the package manager. Query pkg-config
+        // first, since that is the mechanism package managers (apt, pacman,
+        // dnf, Nix, ...) use to advertise correct include/lib paths; only
+        // fall back to the hardcoded search paths above when pkg-config is
+        // unavailable or does not know about UMFPACK (e.g., nixpkgs'
+        // `suitesparse` package currently ships no .pc files at all).
         #[cfg(all(not(feature = "cudss"), not(feature = "local_sparse")))]
         {
-            cc::Build::new()
+            let umfpack = probe_umfpack();
+
+            let mut build = cc::Build::new();
+            build
                 .file("c_code/interface_complex_umfpack.c")
-                .file("c_code/interface_umfpack.c")
-                .includes(&inc_dirs)
-                .compile("c_code");
-            for d in &lib_dirs {
-                println!("cargo:rustc-link-search=native={}", *d);
+                .file("c_code/interface_umfpack.c");
+
+            match &umfpack {
+                Some(lib) => {
+                    for inc in &lib.include_paths {
+                        build.include(inc);
+                    }
+                }
+                None => {
+                    build.includes(&inc_dirs);
+                }
             }
-            println!("cargo:rustc-link-lib=dylib=umfpack");
+            build.compile("c_code");
+
+            match umfpack {
+                Some(lib) => {
+                    // pkg-config already emitted the correct
+                    // cargo:rustc-link-search/cargo:rustc-link-lib directives
+                    // (see pkg_config::Config::probe).
+                    let _ = lib;
+                }
+                None => {
+                    for d in &lib_dirs {
+                        println!("cargo:rustc-link-search=native={}", *d);
+                    }
+                    println!("cargo:rustc-link-lib=dylib=umfpack");
+                }
+            }
         }
     }
+}
+
+/// Returns the list of directories (from `dirs`) that actually exist on disk.
+///
+/// This is used to build the fallback include/lib search paths without
+/// polluting the compiler/linker command line with directories that don't
+/// exist, which could otherwise mask errors or interact poorly with
+/// environment-injected flags (e.g., Nix's NIX_CFLAGS_COMPILE/NIX_LDFLAGS).
+#[cfg(not(target_os = "windows"))]
+fn existing_dirs(dirs: &[&str]) -> Vec<String> {
+    dirs.iter()
+        .filter(|d| std::path::Path::new(d).is_dir())
+        .map(|d| d.to_string())
+        .collect()
+}
+
+/// Probes `pkg-config` for the UMFPACK library (and transitively AMD, CHOLMOD,
+/// SuiteSparse_config, etc., via `Requires.private`).
+///
+/// SuiteSparse's pkg-config files are inconsistently cased across
+/// distributions/build systems (Debian, Arch, and a plain `make install` of
+/// upstream SuiteSparse all use `UMFPACK.pc`, while some vendored setups use
+/// lowercase `umfpack.pc`), so both spellings are tried. Returns `None` if
+/// pkg-config itself is missing or if it cannot find UMFPACK under either
+/// name (e.g., nixpkgs' `suitesparse` package ships no .pc files).
+#[cfg(all(not(target_os = "windows"), not(feature = "cudss"), not(feature = "local_sparse")))]
+fn probe_umfpack() -> Option<pkg_config::Library> {
+    for name in ["UMFPACK", "umfpack"] {
+        match pkg_config::Config::new().probe(name) {
+            Ok(lib) => return Some(lib),
+            // The library just isn't known under this name; try the other spelling.
+            Err(pkg_config::Error::ProbeFailure { .. }) | Err(pkg_config::Error::Failure { .. }) => continue,
+            // pkg-config itself is missing, or cross-compiling without a sysroot:
+            // retrying with a different library name would not help.
+            Err(_) => break,
+        }
+    }
+    None
 }
 
 /// Returns the CXX compiler to use for cuDSS compilation.

--- a/russell_sparse/build.rs
+++ b/russell_sparse/build.rs
@@ -78,14 +78,10 @@ fn main() {
 
     #[cfg(not(target_os = "windows"))]
     {
-        // Fallback search directories, used only when pkg-config cannot locate
-        // the required libraries (e.g., locally compiled SuiteSparse/MUMPS via
-        // zscripts/*-compile-*.bash, Homebrew, or the proprietary cuDSS
-        // distribution — none of which ship .pc files). Non-existing
-        // directories are filtered out so that they never end up as bogus
-        // `-I`/`-L` flags on the compiler/linker command line; besides being
-        // noisy, stale entries like `/usr/lib` can shadow the libraries that
-        // an active Nix devShell injects via NIX_CFLAGS_COMPILE/NIX_LDFLAGS.
+        // Used only when `pkg-config` comes up empty: locally compiled
+        // SuiteSparse/MUMPS, Homebrew and cuDSS ship no `.pc` files.
+        // Directories that do not exist are dropped — apart from being noise,
+        // entries like `/usr/lib` can shadow what a Nix devShell provides.
         let inc_dirs = existing_dirs(&[
             "/opt/homebrew/include/suitesparse",
             "/usr/include/suitesparse",
@@ -184,13 +180,11 @@ fn main() {
 
         // not(cudss) && not(local_sparse)
         //
-        // This is "Option 1" in README.md: UMFPACK (and its SuiteSparse
-        // dependencies) coming from the package manager. Query pkg-config
-        // first, since that is the mechanism package managers (apt, pacman,
-        // dnf, Nix, ...) use to advertise correct include/lib paths; only
-        // fall back to the hardcoded search paths above when pkg-config is
-        // unavailable or does not know about UMFPACK (e.g., nixpkgs'
-        // `suitesparse` package currently ships no .pc files at all).
+        // "Option 1" from README.md: UMFPACK straight from the package
+        // manager. Ask pkg-config first, as that is how package managers
+        // publish their include/lib paths, and fall back to the paths above
+        // when it knows nothing about UMFPACK — nixpkgs' suitesparse, for
+        // one, ships no .pc files.
         #[cfg(all(not(feature = "cudss"), not(feature = "local_sparse")))]
         {
             let umfpack = probe_umfpack();
@@ -214,9 +208,7 @@ fn main() {
 
             match umfpack {
                 Some(lib) => {
-                    // pkg-config already emitted the correct
-                    // cargo:rustc-link-search/cargo:rustc-link-lib directives
-                    // (see pkg_config::Config::probe).
+                    // probe() has already emitted the link directives.
                     let _ = lib;
                 }
                 None => {
@@ -230,12 +222,8 @@ fn main() {
     }
 }
 
-/// Returns the list of directories (from `dirs`) that actually exist on disk.
-///
-/// This is used to build the fallback include/lib search paths without
-/// polluting the compiler/linker command line with directories that don't
-/// exist, which could otherwise mask errors or interact poorly with
-/// environment-injected flags (e.g., Nix's NIX_CFLAGS_COMPILE/NIX_LDFLAGS).
+/// Keeps only the directories that exist, so the fallback does not litter the
+/// command line with `-I`/`-L` entries pointing nowhere.
 #[cfg(not(target_os = "windows"))]
 fn existing_dirs(dirs: &[&str]) -> Vec<String> {
     dirs.iter()
@@ -244,15 +232,13 @@ fn existing_dirs(dirs: &[&str]) -> Vec<String> {
         .collect()
 }
 
-/// Probes `pkg-config` for the UMFPACK library (and transitively AMD, CHOLMOD,
-/// SuiteSparse_config, etc., via `Requires.private`).
+/// Asks `pkg-config` for UMFPACK, which pulls in AMD, CHOLMOD and friends via
+/// `Requires.private`.
 ///
-/// SuiteSparse's pkg-config files are inconsistently cased across
-/// distributions/build systems (Debian, Arch, and a plain `make install` of
-/// upstream SuiteSparse all use `UMFPACK.pc`, while some vendored setups use
-/// lowercase `umfpack.pc`), so both spellings are tried. Returns `None` if
-/// pkg-config itself is missing or if it cannot find UMFPACK under either
-/// name (e.g., nixpkgs' `suitesparse` package ships no .pc files).
+/// Both spellings are tried because SuiteSparse is inconsistent about it:
+/// Debian, Arch and upstream's own `make install` write `UMFPACK.pc`, while
+/// some setups use lowercase. `None` means pkg-config is missing or does not
+/// know UMFPACK under either name.
 #[cfg(all(not(target_os = "windows"), not(feature = "cudss"), not(feature = "local_sparse")))]
 fn probe_umfpack() -> Option<pkg_config::Library> {
     for name in ["UMFPACK", "umfpack"] {


### PR DESCRIPTION
When I started building code depending on `russell_ode` + `russell_sparse` on Ubuntu 26.04 with Nix 24.06 `cargo test` started failing on attempt to link `libm` with wrong `glibc` version. Quick peek into `build.rs` of `russell_sparse` revealed the cause - hardcoded paths took precedent over _complex_ Nix path of active environment.

This is proposed fix relying on _industry standard_ `pkg-config` with fallback to _old ways_ in case of failure. Some testing shows it OKish solution. In the ideal works we'd have code searching for directories with right header files and right libraries if `pkg-config` fails, but we'd need trustworthy sources what these files are.

This is a blocking issue for our project. Thank you for considering this.